### PR TITLE
Use external Hatanaka library for RINEX decompression

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,10 +63,11 @@ USAGE :
 
 # Requirements
 
-The tool is in Python 3, your must have it installed on your machine.
+The tool is in Python 3, you must have it installed on your machine. Install Hatanaka for RINEX decompression.
 
-You have to have RNX2CRZ, CRZ2RNX, RNX2CRX and CRX2RNX installed and declared in your path. The RNXCMP program package must be present on the machine, if not, available there :
-http://terras.gsi.go.jp/ja/crx2rnx.html
+```bash
+pip install hatanaka
+```
 
 To declare it in your path, run on linux :
 

--- a/crzmeta.py
+++ b/crzmeta.py
@@ -8,10 +8,6 @@ EXAMPLE:
 
 REQUIREMENTS :
 
-You have to have RNX2CRZ and CRZ2RNX installed and declared in your path.
-The program must be present on the machine, if not, available there :
-http://terras.gsi.go.jp/ja/crx2rnx.html
-
 You have to have teqc installed and declared in your path.
 The program must be present on the machine, if not, available there :
 https://www.unavco.org/software/data-processing/teqc/teqc.html#executables
@@ -25,35 +21,7 @@ import os, sys, re
 from   datetime import datetime
 import logging
 from   shutil import copy, move
-
-
-def crz2rnx(file):
-    """
-    Calling 'crz2rnx' program via subprocess to uncomrpess CRX files.
-    The program must be present on the machine, if not, available there :
-    http://terras.gsi.go.jp/ja/crx2rnx.html
-    """
-
-    if not file.endswith('crx.Z') and not file.endswith('d.Z'):
-        success = False
-        rnxfile = None
-        return success, rnxfile
-
-    # crx2rnx -f : force overwriting
-    p = subprocess.Popen(['crz2rnx', '-f', file], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-    out, err = p.communicate()
-
-    if err:
-        success = False
-        rnxfile = None
-    else:
-        success = True
-        if file.endswith('crx.Z'):
-            rnxfile = file[:-5] + 'rnx'
-        elif file.endswith('d.Z'):
-            rnxfile = file[:-3] + 'o'
-
-    return success, rnxfile
+import hatanaka
 
 
 def teqcmeta(file):
@@ -81,13 +49,13 @@ def crzmeta(rinexfile):
     success = copy(rinexfile, temp_folder)
 
     if not success:
-        logger.error('04 - Copy of file to temp directory impossible - ' + rinexfile)
+        logging.error('04 - Copy of file to temp directory impossible - ' + rinexfile)
         return
 
     tempfile = os.path.join(temp_folder, os.path.basename(rinexfile))
 
     ##### Lauchning crz2rnx to extract Rinex file from archive #####
-    success, convertedfile = crz2rnx(tempfile)
+    convertedfile = hatanaka.decompress_on_disk(tempfile)
 
     if not success:
         print('06 - Invalid Compressed Rinex file - ' + rinexfile)

--- a/rinexmod.py
+++ b/rinexmod.py
@@ -72,10 +72,6 @@ EXAMPLES:
 
 REQUIREMENTS :
 
-You have to have RNX2CRZ, CRZ2RNX, RNX2CRX and CRX2RNX installed and declared in
-your path. The program must be present on the machine, if not, available there :
-http://terras.gsi.go.jp/ja/crx2rnx.html
-
 You have to have teqc installed and declared in your path.
 The program must be present on the machine, if not, available there :
 https://www.unavco.org/software/data-processing/teqc/teqc.html#executables
@@ -89,60 +85,9 @@ from   datetime import datetime
 import logging
 from   shutil import copy, move
 import configparser
-import json
 from sitelogs_IGS import Sitelog
+import hatanaka
 
-
-def crz2rnx(file):
-    """
-    Calling 'crz2rnx' program via subprocess to uncomrpess CRX files.
-    The program must be present on the machine, if not, available there :
-    http://terras.gsi.go.jp/ja/crx2rnx.html
-    """
-
-    if not file.endswith('crx.Z') and not file.endswith('d.Z'):
-        success = False
-        rnxfile = None
-        return success, rnxfile
-
-    # crx2rnx -f : force overwriting
-    p = subprocess.Popen(['crz2rnx', '-f', file], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-    out, err = p.communicate()
-
-    if err:
-        success = False
-        rnxfile = err.decode('utf-8')
-    else:
-        success = True
-        if file.endswith('crx.Z'):
-            rnxfile = file[:-5] + 'rnx'
-        elif file.endswith('d.Z'):
-            rnxfile = file[:-3] + 'o'
-
-    return success, rnxfile
-
-
-def rnx2crz(file):
-    """
-    Calling 'rnx2crx' program via subprocess to uncomrpess CRX files.
-    The program must be present on the machine, if not, available there :
-    http://terras.gsi.go.jp/ja/crx2rnx.html
-    """
-    # crx2rnx -f : force overwriting
-    p = subprocess.Popen(['rnx2crz', '-f', file], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-    out, err = p.communicate()
-
-    if err:
-        success = False
-        crzfile = err.decode("utf-8")
-    else:
-        success = True
-        if file.endswith('rnx'):
-            crzfile = file[:-3] + 'crx.Z'
-        elif file.endswith('o'):
-            crzfile = file[:-1] + 'd.Z'
-
-    return success, crzfile
 
 
 def teqcmeta(file):
@@ -371,7 +316,7 @@ def rinexmod(rinexlist, outputfolder, teqcargs, name, single, sitelog, force, re
 
             ##### Lauchning crz2rnx to extract Rinex file from archive #####
             logger.debug('Converting file to RNX')
-            success, convertedfile = crz2rnx(workfile)
+            convertedfile = hatanaka.decompress_on_disk(workfile)
             workfile = convertedfile
 
             if not success:
@@ -441,7 +386,7 @@ def rinexmod(rinexlist, outputfolder, teqcargs, name, single, sitelog, force, re
             if workfile.endswith('.rnx') or re.match(r'\d{2}o', workfile[-3:]):
 
                 logger.debug('Converting file to CRZ')
-                success, crzfile = rnx2crz(workfile)
+                crzfile = hatanaka.decompress_on_disk(workfile)
 
                 if not success:
                     logger.error('08 - Invalid Rinex file - ' + file)


### PR DESCRIPTION
Hi! I recently created a carefully packaged and wrapped version of the RNXCMP tools in Python as the [Hatanaka](https://github.com/valgur/hatanaka) library. It simplifies the installation and usage of the tools and also makes sure any errors are raised as proper exceptions and warnings as Python warnings. In addition to the Hatanaka decompression it can also take care of the .gz/.Z compression usually applied on top of Hatanaka compression.

I thought you might find the library useful as well. It should make using this library a bit simpler, I hope.